### PR TITLE
fix specifying size

### DIFF
--- a/lib/heroku/exit-status.rb
+++ b/lib/heroku/exit-status.rb
@@ -9,7 +9,7 @@ class Heroku::Command::Run < Heroku::Command::Base
 
     app_name = app
     opts = { :attach => true, :ps_env => get_terminal_environment }
-    opts[:size] = get_size if options[:size]
+    opts[:size] = options[:size] if options[:size]
 
     process_data = action("Running `#{command}` attached to terminal", :success => "up") do
       process_data = api.post_ps(app_name, command_with_exit, opts).body


### PR DESCRIPTION
I'm not sure if the latest heroku toolbelt broke this or it never worked, but `get_size` doesn't seem to exist.  This mimics what the official heroku run command does internally.
--Bob
