### PR TITLE
workaround invalid UTF-8 sequences

### DIFF
--- a/lib/heroku/exit-status.rb
+++ b/lib/heroku/exit-status.rb
@@ -32,7 +32,7 @@ class Heroku::Client::Rendezvous
       rescue # ignore failed gsub, for instance when non-utf8
       end
     end
-    if data =~ /\Aheroku-command-exit-status ([\d]+)/
+    if data.encode('UTF-16le', :invalid => :replace, :replace => '').encode('UTF-8') =~ /\Aheroku-command-exit-status ([\d]+)/
       exit $1.to_i
     end
     output.isatty ? data : data.gsub(/\cM/,"")


### PR DESCRIPTION
Had an issue where invalid UTF-8 sequences in my heroku output broke this plugin.  This is a workaround that strips invalid UTF-8 characters so the exit code regexp will work and not raise.
--Bob
